### PR TITLE
Added a --tor switch to cipfs get. Requires cURL

### DIFF
--- a/cipfs.sh
+++ b/cipfs.sh
@@ -85,11 +85,18 @@ x=$2
 FNAME=$(echo "$x" | cut -b 2-47)
 KEY=$(echo "$x" | cut -b 48-$((48+32)))
 
+if [[ " $* " == *' --tor '* ]]; then
+ENTRY_PT=https://ipfs.io
+####################
+## Download from IPFS web entry point via tor
+IPFS_OUTPUT=`curl -o $FNAME -x socks5h://127.0.0.1:9050 $ENTRY_PT/ipfs/$FNAME`
+else
 ####################
 ## Download from IPFS
 IPFS_OUTPUT=`ipfs get $FNAME`
 echo
 echo ... downloaded from IPFS
+fi
 mv $FNAME $FNAME.gpg
 
 ####################


### PR DESCRIPTION
Means that the "get" feature of the CIPFS script doesn't require a local IPFS instance running.
I think this is important - as you can then share the CIPFS script and generated tokens with those who don't themselves run a local IPFS instance.

Allows "get" downloads from a web entry point to IPFS, anonymously, via tor.

Requires local tor service, and availability of cURL.